### PR TITLE
feat: change name of strategy

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -51,7 +51,7 @@ function Strategy(options, verify) {
   options.sessionKey = options.sessionKey || 'oauth:twitter';
   
   OAuthStrategy.call(this, options, verify);
-  this.name = 'twitter';
+  this.name = options.name || 'twitter';
   this._userProfileURL = options.userProfileURL || 'https://api.twitter.com/1.1/account/verify_credentials.json';
   this._skipExtendedUserProfile = (options.skipExtendedUserProfile !== undefined) ? options.skipExtendedUserProfile : false;
   this._includeEmail = (options.includeEmail !== undefined) ? options.includeEmail : false;


### PR DESCRIPTION
You can customize the name of the policy. Because I need to implement a special use case. I need to load two identical policies in NestJS, one `forceLogin = true`, and one `forceLogin = false`.